### PR TITLE
Improve first message experience

### DIFF
--- a/app/src/app/chat/[id]/loading.tsx
+++ b/app/src/app/chat/[id]/loading.tsx
@@ -1,0 +1,58 @@
+import ChatContainer from "../../../components/chat/chat-container";
+import {
+  ChatThreadCenterContainer,
+  ChatThreadInputContainer,
+} from "../../../components/chat/thread/chat-thread-components";
+import { Skeleton } from "../../../components/ui/skeleton";
+
+export default function ChatLoading() {
+  return (
+    <ChatContainer>
+      <ChatThreadCenterContainer>
+        <div className="flex h-full w-full flex-col space-y-12 p-6 md:p-8">
+          {/* User message skeleton */}
+          <div className="flex w-full flex-col gap-4">
+            <div className="flex items-center justify-end gap-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-8 w-8 rounded-full" />
+            </div>
+            <div className="flex flex-col items-end gap-2">
+              <Skeleton className="h-4 w-full max-w-[75%]" />
+              <Skeleton className="h-4 w-full max-w-[85%]" />
+            </div>
+          </div>
+          {/* Assistant message skeleton */}
+          <div className="flex w-full flex-col gap-4">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-8 w-8 rounded-full" />
+              <Skeleton className="h-5 w-20" />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-4 w-full max-w-[80%]" />
+              <Skeleton className="h-4 w-full max-w-[70%]" />
+              <Skeleton className="h-4 w-full max-w-[60%]" />
+              <Skeleton className="h-4 w-full max-w-[80%]" />
+              <Skeleton className="h-4 w-full max-w-[80%]" />
+            </div>
+          </div>
+          {/* User message skeleton */}
+          <div className="flex w-full flex-col gap-4">
+            <div className="flex items-center justify-end gap-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-8 w-8 rounded-full" />
+            </div>
+            <div className="flex flex-col items-end gap-2">
+              <Skeleton className="h-4 w-full max-w-[85%]" />
+              <Skeleton className="h-4 w-full max-w-[75%]" />
+            </div>
+          </div>
+        </div>
+
+        {/* Input skeleton */}
+        <ChatThreadInputContainer>
+          <Skeleton className="h-24 w-full rounded-md" />
+        </ChatThreadInputContainer>
+      </ChatThreadCenterContainer>
+    </ChatContainer>
+  );
+}

--- a/app/src/components/chat/chat-threads-sidebar.tsx
+++ b/app/src/components/chat/chat-threads-sidebar.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { type ChatThread } from "@prisma/client";
 import { MessageCirclePlus } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { useMemo } from "react";
 import { cn } from "../../lib/utils";
 import { api } from "../../trpc/react";
 import Header from "../header/header";
@@ -14,12 +16,14 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../ui/tooltip";
+import { groupThreadsByDate } from "./chat-utils";
 
 export default function ChatThreadsSidebar() {
-  const path = usePathname();
-  const router = useRouter();
-
   const { data: threads } = api.chat.getThreads.useQuery();
+
+  const groupedThreads = useMemo(() => {
+    return groupThreadsByDate(threads ?? []);
+  }, [threads]);
 
   return (
     <>
@@ -54,39 +58,76 @@ export default function ChatThreadsSidebar() {
               </span>
             </div>
           ) : (
-            threads?.map((thread) => (
-              <Link
-                key={thread.id}
-                href={`/chat/${thread.id}`}
-                onMouseEnter={() => router.prefetch(`/chat/${thread.id}`)}
-                onFocus={() => router.prefetch(`/chat/${thread.id}`)}
-              >
-                <div
-                  className={cn(
-                    "flex items-center rounded-md p-2 text-sm hover:bg-sidebar",
-                    path.includes(`/chat/${thread.id}`) &&
-                      "bg-muted font-medium",
-                  )}
-                >
-                  <div className="flex flex-col gap-0.5 overflow-hidden">
-                    <span className="truncate">{thread.title}</span>
-                    <span className="text-xs text-muted-foreground">
-                      {`${thread.created_at.toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                      })} at ${thread.created_at.toLocaleTimeString("en-US", {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}`}
-                    </span>
-                  </div>
-                </div>
-              </Link>
-            ))
+            <>
+              {groupedThreads.today.length > 0 && (
+                <ThreadGroup title="Today" threads={groupedThreads.today} />
+              )}
+              {groupedThreads.yesterday.length > 0 && (
+                <ThreadGroup
+                  title="Yesterday"
+                  threads={groupedThreads.yesterday}
+                />
+              )}
+              {groupedThreads.older.length > 0 && (
+                <ThreadGroup title="Older" threads={groupedThreads.older} />
+              )}
+            </>
           )}
         </div>
       </ResizablePanel>
       <ResizableHandle withHandle={true} />
     </>
+  );
+}
+
+function ThreadGroup({
+  title,
+  threads,
+}: {
+  title: string;
+  threads: ChatThread[];
+}) {
+  return (
+    <div className="mt-2">
+      <h3 className="mb-1 px-2 text-xs font-medium text-muted-foreground">
+        {title}
+      </h3>
+      <div className="flex flex-col gap-1">
+        {threads.map((thread) => (
+          <ThreadItem key={thread.id} thread={thread} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ThreadItem({ thread }: { thread: ChatThread }) {
+  const path = usePathname();
+  const router = useRouter();
+
+  const isActive = path.includes(`/chat/${thread.id}`);
+
+  function handlePrefetch() {
+    router.prefetch(`/chat/${thread.id}`);
+  }
+
+  return (
+    <Link
+      key={thread.id}
+      href={`/chat/${thread.id}`}
+      onMouseEnter={handlePrefetch}
+      onFocus={handlePrefetch}
+    >
+      <div
+        className={cn(
+          "flex items-center rounded-md p-2 text-sm hover:bg-sidebar",
+          isActive && "bg-muted font-medium",
+        )}
+      >
+        <div className="flex flex-col gap-0.5 overflow-hidden">
+          <span className="truncate">{thread.title}</span>
+        </div>
+      </div>
+    </Link>
   );
 }

--- a/app/src/components/chat/chat-utils.tsx
+++ b/app/src/components/chat/chat-utils.tsx
@@ -1,3 +1,4 @@
+import { type ChatThread } from "@prisma/client";
 import { BOOKS } from "../../server/utils/bible-utils";
 
 const bookNames = BOOKS.map((b) => b.name);
@@ -74,4 +75,52 @@ export function parseBibleReferenceDetails(reference: string): {
       startChapter: chapter,
     };
   }
+}
+
+export function isToday(date: Date): boolean {
+  const today = new Date();
+  return (
+    date.getDate() === today.getDate() &&
+    date.getMonth() === today.getMonth() &&
+    date.getFullYear() === today.getFullYear()
+  );
+}
+
+export function isYesterday(date: Date): boolean {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  return (
+    date.getDate() === yesterday.getDate() &&
+    date.getMonth() === yesterday.getMonth() &&
+    date.getFullYear() === yesterday.getFullYear()
+  );
+}
+
+export function groupThreadsByDate(threads: ChatThread[]): {
+  today: ChatThread[];
+  yesterday: ChatThread[];
+  older: ChatThread[];
+} {
+  if (!threads) return { today: [], yesterday: [], older: [] };
+
+  return threads.reduce(
+    (acc, thread) => {
+      const threadDate = new Date(thread.created_at);
+
+      if (isToday(threadDate)) {
+        acc.today.push(thread);
+      } else if (isYesterday(threadDate)) {
+        acc.yesterday.push(thread);
+      } else {
+        acc.older.push(thread);
+      }
+
+      return acc;
+    },
+    {
+      today: [] as ChatThread[],
+      yesterday: [] as ChatThread[],
+      older: [] as ChatThread[],
+    },
+  );
 }


### PR DESCRIPTION
Improvements to flow for creating a new chat thread
- optimistically add chat thread to sidebar
- make logic for creating a title non-blocking in createThread
- add `loading.tsx` for `/chat/[id]`
- ui/ux: group chats between today, yesterday, and older